### PR TITLE
Add 'endorsed' field to posts (0 or 1)

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -473,6 +473,30 @@ postsAPI.unbookmark = async function (caller, data) {
 	return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
+postsAPI.endorse = async function (caller, data) {
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const exists = await posts.exists(data.pid);
+	if (!exists) {
+		throw new Error('[[error:invalid-pid]]');
+	}
+	await posts.setPostField(data.pid, 'endorsed', 1);
+	return { pid: data.pid, endorsed: 1 };
+};
+
+postsAPI.unendorse = async function (caller, data) {
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const exists = await posts.exists(data.pid);
+	if (!exists) {
+		throw new Error('[[error:invalid-pid]]');
+	}
+	await posts.setPostField(data.pid, 'endorsed', 0);
+	return { pid: data.pid, endorsed: 0 };
+};
+
 async function diffsPrivilegeCheck(pid, uid) {
 	const [deleted, privilegesData] = await Promise.all([
 		posts.getPostField(pid, 'deleted'),

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -163,6 +163,16 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.endorse = async (req, res) => {
+	const result = await api.posts.endorse(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res, result);
+};
+
+Posts.unendorse = async (req, res) => {
+	const result = await api.posts.unendorse(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res, result);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -28,7 +28,7 @@ module.exports = function (Posts) {
 		}
 
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
-		let postData = { pid, uid, tid, content, sourceContent, timestamp };
+		let postData = { pid, uid, tid, content, sourceContent, timestamp, endorsed: 0 };
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'endorsed',
 ];
 
 module.exports = function (Posts) {

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -34,6 +34,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
+	setupApiRoute(router, 'put', '/:pid/endorse', middlewares, controllers.write.posts.endorse);
+	setupApiRoute(router, 'delete', '/:pid/endorse', middlewares, controllers.write.posts.unendorse);
+
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);


### PR DESCRIPTION
This is the first step to implementing database logic for endorsing posts (#13 )
- Add 'endorsed' to intFields for proper integer parsing
- Initialize endorsed=0 on post creation
- Add endorse/unendorse API endpoints (PUT/DELETE /api/v3/posts/:pid/endorse)
- Add corresponding controller and route wiring

https://claude.ai/code/session_015H7tVc6LK7fwqr4tMk2psJ