### PR TITLE
Wire up endorse button end-to-end with UI toggle, privilege checks, a…

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -263,5 +263,6 @@
 	"announcers": "Shares",
 	"announcers-x": "Shares (%1)",
 	"endorse": "Endorse",
-    "unendorse": "Unendorse"
+    "unendorse": "Unendorse",
+    "endorsed": "Endorsed"
 }

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -232,5 +232,6 @@
     "announcers": "Shares",
     "announcers-x": "Shares (%1)",
     "endorse": "Endorse",
-    "unendorse": "Unendorse"
+    "unendorse": "Unendorse",
+    "endorsed": "Endorsed"
 }

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -44,6 +44,7 @@ define('forum/topic/events', [
 		'posts.downvote': togglePostVote,
 		'posts.unvote': togglePostVote,
 
+		'event:post_endorsed': onPostEndorsed,
 		'event:new_notification': onNewNotification,
 		'event:new_post': posts.onNewPost,
 	};
@@ -246,6 +247,24 @@ define('forum/topic/events', [
 
 		el.find('[component="post/bookmark/on"]').toggleClass('hidden', !data.isBookmarked);
 		el.find('[component="post/bookmark/off"]').toggleClass('hidden', data.isBookmarked);
+	}
+
+	function onPostEndorsed(data) {
+		if (!data || !data.pid) {
+			return;
+		}
+		const postEl = components.get('post', 'pid', data.pid);
+		if (!postEl.length) {
+			return;
+		}
+		const isEndorsed = !!data.endorsed;
+		postEl.toggleClass('endorsed', isEndorsed);
+
+		// Toggle the endorsed indicator badge in the post header
+		postEl.find('[component="post/endorsed-indicator"]').toggleClass('opacity-0', !isEndorsed);
+
+		// Force dropdown menu reload on next open so it reflects the new state
+		postTools.removeMenu(postEl);
 	}
 
 	function togglePostVote(data) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -290,15 +290,9 @@ define('forum/topic/postTools', [
 			openChat($(this));
 		});
 
-		console.log('post tools initialized');
-		console.log('post privileges', ajaxify.data.privileges);
-
-		//if (ajaxify.data.privileges['posts:endorse']) {
 		postContainer.on('click', '[component="post/endorse"]', function () {
 			toggleEndorse($(this));
-			console.log('endorsing post');
 		});
-		//}
 	}
 
 	async function onReplyClicked(button, tid) {
@@ -443,10 +437,10 @@ define('forum/topic/postTools', [
 
 	async function toggleEndorse(button) {
 		const pid = getData(button, 'data-pid');
-		const postEl = components.get('post', 'pid', pid);
-		var action = !postEl.hasClass('endorsed') ? 'put' : 'del';
-		console.log('toggling endorse', action, pid);
-		api[action](`/posts/${encodeURIComponent(pid)}/endorse`).catch(alerts.error);
+		const endorseBtn = button.closest('[component="post/endorse"]');
+		const isEndorsed = endorseBtn.attr('data-endorsed') === '1';
+		const method = isEndorsed ? 'del' : 'put';
+		api[method](`/posts/${encodeURIComponent(pid)}/endorse`).catch(alerts.error);
 	}
 
 	async function postAction(action, pid) {

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -477,11 +477,18 @@ postsAPI.endorse = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');
 	}
+	const cid = await posts.getCidByPid(data.pid);
+	const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, caller.uid);
+	if (!isAdminOrMod) {
+		throw new Error('[[error:no-privileges]]');
+	}
 	const exists = await posts.exists(data.pid);
 	if (!exists) {
 		throw new Error('[[error:invalid-pid]]');
 	}
 	await posts.setPostField(data.pid, 'endorsed', 1);
+	const tid = await posts.getPostField(data.pid, 'tid');
+	websockets.in(`topic_${tid}`).emit('event:post_endorsed', { pid: data.pid, endorsed: 1 });
 	return { pid: data.pid, endorsed: 1 };
 };
 
@@ -489,11 +496,18 @@ postsAPI.unendorse = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');
 	}
+	const cid = await posts.getCidByPid(data.pid);
+	const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, caller.uid);
+	if (!isAdminOrMod) {
+		throw new Error('[[error:no-privileges]]');
+	}
 	const exists = await posts.exists(data.pid);
 	if (!exists) {
 		throw new Error('[[error:invalid-pid]]');
 	}
 	await posts.setPostField(data.pid, 'endorsed', 0);
+	const tid = await posts.getPostField(data.pid, 'tid');
+	websockets.in(`topic_${tid}`).emit('event:post_endorsed', { pid: data.pid, endorsed: 0 });
 	return { pid: data.pid, endorsed: 0 };
 };
 

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -20,7 +20,7 @@ module.exports = function (SocketPosts) {
 		}
 		const cid = await posts.getCidByPid(data.pid);
 		const results = await utils.promiseParallel({
-			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url']),
+			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url', 'endorsed']),
 			isAdmin: user.isAdministrator(socket.uid),
 			isGlobalMod: user.isGlobalModerator(socket.uid),
 			isModerator: user.isModerator(socket.uid, cid),

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -93,11 +93,16 @@
 		</a>
 	</li>
 
+	{{{ end }}}
+
+	{{{ if posts.display_moderator_tools }}}
 	<li>
-		<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#">
+		<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#" data-endorsed="{posts.endorsed}">
 			<span class="menu-icon">
-				<i component="post/endorse" class="fa fa-fw text-secondary fa-bookmark "></i>
-			</span> [[topic:endorse]]
+				<i component="post/endorse/on" class="fa fa-fw text-secondary fa-check-circle {{{ if !posts.endorsed }}}hidden{{{ end }}}"></i>
+				<i component="post/endorse/off" class="fa fa-fw text-secondary fa-check-circle-o {{{ if posts.endorsed }}}hidden{{{ end }}}"></i>
+			</span>
+			<span component="post/endorse/text">{{{ if posts.endorsed }}}[[topic:unendorse]]{{{ else }}}[[topic:endorse]]{{{ end }}}</span>
 		</a>
 	</li>
 	{{{ end }}}

--- a/vendor/nodebb-theme-harmony-main/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-main/templates/partials/topic/post.tpl
@@ -75,6 +75,7 @@
 				{{{ end }}}
 			</div>
 			<div class="d-flex align-items-center gap-1 justify-content-end">
+				<span component="post/endorsed-indicator" class="endorsed-indicator {{{ if !posts.endorsed }}}opacity-0{{{ end }}} text-success" title="[[topic:endorsed]]"><i class="fa fa-check-circle"></i></span>
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{encodeURIComponent(./pid)}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>

--- a/vendor/nodebb-theme-harmony-main/templates/topic.tpl
+++ b/vendor/nodebb-theme-harmony-main/templates/topic.tpl
@@ -77,7 +77,7 @@
 					<div class="posts-container" style="min-width: 0;">
 						<ul component="topic" class="posts timeline list-unstyled p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
 						{{{ each posts }}}
-							<li component="post" class="{{{ if (./index != 0) }}}pt-4{{{ end }}} {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+							<li component="post" class="{{{ if (./index != 0) }}}pt-4{{{ end }}} {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}} {{{ if posts.endorsed }}}endorsed{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
 								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
 								<meta itemprop="datePublished" content="{./timestampISO}">
 								{{{ if ./editedISO }}}


### PR DESCRIPTION
Implements the button in the dropdown menu for endorsement. (#17 )
- Template: show endorse/unendorse toggle with icons, restrict to moderators
- API: add admin/mod privilege check, emit websocket events on endorse/unendorse
- Socket handler: include endorsed field in loadPostTools data
- Client JS: fix toggleEndorse to use data-endorsed attribute, remove debug logs
- Events: add onPostEndorsed handler for real-time UI updates across clients
- Theme: add endorsed indicator (check-circle) on post headers, endorsed CSS class
- Locales: add "endorsed" translation string

https://claude.ai/code/session_014eoruhm2UVyiTefaNqPBCx