### PR TITLE
Replace isAdminOrMod check with dedicated posts:endorse privilege

### DIFF
--- a/public/language/en-GB/admin/manage/privileges.json
+++ b/public/language/en-GB/admin/manage/privileges.json
@@ -37,6 +37,7 @@
 	"view-deleted": "View Deleted Posts",
 	"upvote-posts": "Upvote Posts",
 	"downvote-posts": "Downvote Posts",
+	"endorse-posts": "Endorse Posts",
 	"delete-topics": "Delete Topics",
 	"purge": "Purge",
 	"moderate": "Moderate",

--- a/public/language/en-US/admin/manage/privileges.json
+++ b/public/language/en-US/admin/manage/privileges.json
@@ -37,6 +37,7 @@
 	"view-deleted": "View Deleted Posts",
 	"upvote-posts": "Upvote Posts",
 	"downvote-posts": "Downvote Posts",
+	"endorse-posts": "Endorse Posts",
 	"delete-topics": "Delete Topics",
 	"purge": "Purge",
 	"moderate": "Moderate",

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -477,9 +477,8 @@ postsAPI.endorse = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const cid = await posts.getCidByPid(data.pid);
-	const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, caller.uid);
-	if (!isAdminOrMod) {
+	const canEndorse = await privileges.posts.can('posts:endorse', data.pid, caller.uid);
+	if (!canEndorse) {
 		throw new Error('[[error:no-privileges]]');
 	}
 	const exists = await posts.exists(data.pid);
@@ -496,9 +495,8 @@ postsAPI.unendorse = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const cid = await posts.getCidByPid(data.pid);
-	const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, caller.uid);
-	if (!isAdminOrMod) {
+	const canEndorse = await privileges.posts.can('posts:endorse', data.pid, caller.uid);
+	if (!canEndorse) {
 		throw new Error('[[error:no-privileges]]');
 	}
 	const exists = await posts.exists(data.pid);

--- a/src/categories/create.js
+++ b/src/categories/create.js
@@ -69,6 +69,7 @@ module.exports = function (Categories) {
 		];
 		const modPrivileges = defaultPrivileges.concat([
 			'groups:topics:schedule',
+			'groups:posts:endorse',
 			'groups:posts:view_deleted',
 			'groups:purge',
 		]);

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -30,6 +30,7 @@ const _privilegeMap = new Map([
 	['posts:delete', { label: '[[admin/manage/privileges:delete-posts]]', type: 'posting' }],
 	['posts:upvote', { label: '[[admin/manage/privileges:upvote-posts]]', type: 'posting' }],
 	['posts:downvote', { label: '[[admin/manage/privileges:downvote-posts]]', type: 'posting' }],
+	['posts:endorse', { label: '[[admin/manage/privileges:endorse-posts]]', type: 'moderation' }],
 	['topics:delete', { label: '[[admin/manage/privileges:delete-topics]]', type: 'posting' }],
 	['posts:view_deleted', { label: '[[admin/manage/privileges:view-deleted]]', type: 'moderation' }],
 	['purge', { label: '[[admin/manage/privileges:purge]]', type: 'moderation' }],

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -21,7 +21,7 @@ privsTopics.get = async function (tid, uid) {
 		'topics:reply', 'topics:read', 'topics:schedule', 'topics:tag',
 		'topics:delete', 'posts:edit', 'posts:history',
 		'posts:upvote', 'posts:downvote',
-		'posts:delete', 'posts:view_deleted', 'read', 'purge',
+		'posts:delete', 'posts:endorse', 'posts:view_deleted', 'read', 'purge',
 	];
 	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']);
 	const [userPrivileges, isAdministrator, isModerator, disabled, topicTools] = await Promise.all([
@@ -54,6 +54,7 @@ privsTopics.get = async function (tid, uid) {
 		'posts:upvote': privData['posts:upvote'] || isAdministrator,
 		'posts:downvote': privData['posts:downvote'] || isAdministrator,
 		'posts:delete': (privData['posts:delete'] && (!topicData.locked || isModerator)) || isAdministrator,
+		'posts:endorse': privData['posts:endorse'] || isAdministrator,
 		'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
 		read: privData.read || isAdministrator,
 		purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -29,6 +29,7 @@ module.exports = function (SocketPosts) {
 			canPurge: privileges.posts.canPurge(data.pid, socket.uid),
 			canFlag: privileges.posts.canFlag(data.pid, socket.uid),
 			canViewHistory: privileges.posts.can('posts:history', data.pid, socket.uid),
+			canEndorse: privileges.posts.can('posts:endorse', data.pid, socket.uid),
 			flagged: flags.exists('post', data.pid, socket.uid), // specifically, whether THIS calling user flagged
 			bookmarked: posts.hasBookmarked(data.pid, socket.uid),
 			postSharing: social.getActivePostSharing(),
@@ -51,6 +52,7 @@ module.exports = function (SocketPosts) {
 		postData.display_manage_editors_tools = results.isAdmin || results.isModerator || postData.selfPost;
 		postData.display_ip_ban = (results.isAdmin || results.isGlobalMod) && !postData.selfPost;
 		postData.display_history = results.history && results.canViewHistory;
+		postData.display_endorse_tools = results.canEndorse;
 		postData.display_original_url = !utils.isNumber(data.pid);
 		postData.flags = {
 			flagId: parseInt(results.posts.flagId, 10) || null,

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -167,6 +167,7 @@ module.exports = function (Topics) {
 				post.display_edit_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:edit']);
 				post.display_delete_tools = topicPrivileges.isAdminOrMod || (post.selfPost && topicPrivileges['posts:delete']);
 				post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
+				post.display_endorse_tools = topicPrivileges['posts:endorse'];
 				post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
 				post.display_post_menu = topicPrivileges.isAdminOrMod ||
 					(post.selfPost && !topicData.locked && !post.deleted) ||

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -95,7 +95,7 @@
 
 	{{{ end }}}
 
-	{{{ if posts.display_moderator_tools }}}
+	{{{ if posts.display_endorse_tools }}}
 	<li>
 		<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#" data-endorsed="{posts.endorsed}">
 			<span class="menu-icon">


### PR DESCRIPTION
Endorsing posts has now become a distinct privilege, and can be toggled for separate groups and users.

- Register 'posts:endorse' in category privilege map (moderation type)
- Add to topics.get() privilege check and returned privilege object
- Give default endorse privilege to admins/mods on new category creation
- Update API endorse/unendorse to use privileges.posts.can('posts:endorse')
- Add canEndorse check and display_endorse_tools flag in socket handler
- Set display_endorse_tools in modifyPostsByPrivilege from topic privileges
- Update template to gate endorse button on display_endorse_tools
- Add 'endorse-posts' admin UI label in en-US and en-GB locales

Tested by inspection (the button exists, and those with privilege can endorse)
https://claude.ai/code/session_014eoruhm2UVyiTefaNqPBCx