### PR TITLE
Mock translation results in tests

### DIFF
--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -15,7 +15,6 @@ translatorApi.translate = async function (postData) {
 		return [true, postData.content];
 	}
 
-//  Edit the translator URL below
 	const TRANSLATOR_API = 'http://17313-team06.s3d.cmu.edu:5000';
 	try{
 		const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -10,19 +10,12 @@ const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
 //  Edit the translator URL below
-	const TRANSLATOR_API = 'http://host.docker.internal:5000';
+	const TRANSLATOR_API = 'http://17313-team06.s3d.cmu.edu:5000';
 	try{
-		// console.log('fetching from');
-		// console.log(TRANSLATOR_API + '/?content=' + postData.content);
 		const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
 		const data = await response.json();
-		// console.log('Success');
-		// console.log(data.is_english);
-		// console.log(data.translated_content);
-		// console.log('content output above');
 		return [data.is_english, data.translated_content];
 	} catch (e) {
-		console.log('Not good');
 		return ['is_english', postData];
 	}
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -9,6 +9,12 @@ const translatorApi = module.exports;
 // };
 
 translatorApi.translate = async function (postData) {
+	// In CI/test environments, skip the external HTTP call to prevent timeouts.
+	// process.env.CI is set to 'true' by test/mocks/databasemock.js.
+	if (process.env.CI === 'true') {
+		return [true, postData.content];
+	}
+
 //  Edit the translator URL below
 	const TRANSLATOR_API = 'http://17313-team06.s3d.cmu.edu:5000';
 	try{


### PR DESCRIPTION
The translation service takes too long to run since it needs to start the LLM. This change adds a check so that the translation service does not run in tests.

Changelog:

- src/translate/index.js: Add a check so that if process.env.CI = 'true' then we use mock results instead of real results