### PR TITLE
fix: microservice API URL for VM deployment

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -8,6 +8,8 @@ services:
     restart: unless-stopped
     ports:
       - '4567:4567' # comment this out if you don't want to expose NodeBB to the host, or change the first number to any port you want
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - nodebb-build:/usr/src/app/build
       - nodebb-uploads:/usr/src/app/public/uploads

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -15,7 +15,7 @@ translatorApi.translate = async function (postData) {
 		return [true, postData.content];
 	}
 
-	const TRANSLATOR_API = 'http://17313-team06.s3d.cmu.edu:5000';
+	const TRANSLATOR_API = 'http://host.docker.internal:5000';
 	try{
 		const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
 		const data = await response.json();


### PR DESCRIPTION
I really hope this is the last time I am changing that line... But I changed the translator API URL so that it works on the VM. I also modified docker-compose-redis.yml to make it work.

Changelog:

- src/translate/index.js: Changed TRANSLATOR_API (for hopefully the last time)
- docker-compose-redis.yml: Added extra_ports so that NodeBB can access external ports in localhost